### PR TITLE
Lazy load payment checkout routes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,7 +3,6 @@ import { AuthGuard } from './core/guards/auth.guard';
 import { RoleGuard } from './core/guards/role.guard';
 import { HomeComponent } from "./features/home/components/home/home.component";
 import { InstructorProfileComponent } from "./features/instructor/components/instructor-profile/instructor-profile.component";
-import { PaymentCheckoutComponent } from "./features/payment/components/payment-checkout/payment-checkout.component";
 
 // Error Pages
 import { Error403Component } from "./features/pages/error-403/error-403.component";
@@ -92,10 +91,9 @@ export const routes: Routes = [
 
   // Ödeme sayfası
   {
-    path: 'checkout/:courseId',
-    component: PaymentCheckoutComponent,
+    path: 'checkout',
     canActivate: [AuthGuard],
-    title: 'Ödeme'
+    loadChildren: () => import('./features/payment/payment.routes').then(m => m.PAYMENT_ROUTES)
   },
 
   // ========== YASAL SAYFALAR ==========

--- a/src/app/features/payment/payment.routes.ts
+++ b/src/app/features/payment/payment.routes.ts
@@ -1,0 +1,15 @@
+import { Routes } from '@angular/router';
+
+import { PaymentCheckoutComponent } from './components/payment-checkout/payment-checkout.component';
+
+/**
+ * Payment feature routes.
+ * These routes are mounted under the `/checkout` path via lazy loading.
+ */
+export const PAYMENT_ROUTES: Routes = [
+  {
+    path: ':courseId',
+    component: PaymentCheckoutComponent,
+    title: 'Ödeme'
+  }
+];


### PR DESCRIPTION
## Summary
- add payment feature route definitions for the checkout component
- lazy load the payment feature from the root router configuration

## Testing
- npm run build *(fails: Cannot find module '/workspace/education-center-frontend/node_modules/cliui/build/index.cjs')*

------
https://chatgpt.com/codex/tasks/task_e_68dae21ca4cc832298b39a78f3e04a46